### PR TITLE
API Keyが必要ないメソッドを実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,6 @@ version = "0.1.0"
 dependencies = [
  "reqwest",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 [dependencies]
 reqwest = { version = "0.12.8", features = ["json", "blocking"] }
 serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.128"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 use std::error::Error;
 
-use response::achievement;
 use response::news::NewsItem;
 use response::News;
 use response::Achievement;
@@ -17,15 +16,15 @@ impl SteamAPI {
     const URL_API_BASE: &'static str =  "http://api.steampowered.com";
     const MAX_LENGTH_NEWS: i32 = 300;
 
+    fn create_base_url(&self, interface: &str, method: &str, version: &str) -> String {
+        format!("{}/{}/{}/v{}/", SteamAPI::URL_API_BASE, interface, method, version)
+    }
+
     pub fn new() -> Result<SteamAPI, Box<dyn Error>> {
         let client = reqwest::blocking::ClientBuilder::new()
             .timeout(Duration::from_secs(10))
             .build()?;
         Ok(SteamAPI{client})
-    }
-
-    fn create_base_url(&self, interface: &str, method: &str, version: &str) -> String {
-        format!("{}/{}/{}/v{}/", SteamAPI::URL_API_BASE, interface, method, version)
     }
 
     pub fn get_news_for_app(&self, app_id: i32, count: i32) -> Result<Vec<NewsItem>, Box<dyn Error>> {
@@ -71,26 +70,30 @@ impl SteamAPI {
 #[cfg(test)]
 mod tests {
     use super::*;
+    const ID_ENDER_LILIES: i32 = 1369630;
+    const ID_ENDER_MAGNOLIA: i32 = 2725260;
 
     #[test]
-    fn it_works() {
-        // API creation.
-        let id_ender_lilies = 1369630;
-        let id_ender_magnolia = 2725260;
+    fn get_news() {
+        // create API
         let api = SteamAPI::new().unwrap();
-        // Test get news
-        let news = api.get_news_for_app(id_ender_lilies, 10);
+        let news = api.get_news_for_app(ID_ENDER_LILIES, 10);
         assert!(news.is_ok());
-        // let news = news.unwrap();
-        // println!("{news:?}");
-        // Test get achievements
+        println!("get news test have passed.");
+    }
+
+    #[test]
+    fn get_achievements() {
+        // create API
+        let api = SteamAPI::new().unwrap();
         // for game which have achievements.
-        let achievements = api.get_global_achievement_percentages_for_app(id_ender_lilies);
+        let achievements = api.get_global_achievement_percentages_for_app(ID_ENDER_LILIES);
         assert!(achievements.is_ok());
         let achievements = achievements.unwrap();
         assert_ne!(achievements.len(), 0);
         // for game which have NO achievements.
-        let achievements = api.get_global_achievement_percentages_for_app(id_ender_magnolia);
+        let achievements = api.get_global_achievement_percentages_for_app(ID_ENDER_MAGNOLIA);
         assert!(achievements.is_ok());
+        println!("get achievements test have passed.");
     }
 }


### PR DESCRIPTION
steam API keyの取得方法の説明がぜんぜん足りなくてわからずリクエスト回数が多すぎますとかでAPI Keyがしばらく取得できなくなったので一旦API Keyが必要ないメソッドをある程度実装したところまでmasterを進める。